### PR TITLE
fix: extend path in function

### DIFF
--- a/conf.d/jq-repl.fish
+++ b/conf.d/jq-repl.fish
@@ -5,6 +5,7 @@ function __lbuffer_strip_trailing_pipe
 end
 
 function __get_query
+    set --local --export --prepend PATH $__fish_config_dir/conf.d/jq_repl_bin
     jq-repl -- $(__lbuffer_strip_trailing_pipe)
     return $status
 end
@@ -29,5 +30,3 @@ end
 
 bind --mode insert \ej _jq_complete
 bind --mode default \ej _jq_complete
-
-fish_add_path $__fish_config_dir/conf.d/jq_repl_bin


### PR DESCRIPTION
I've packaged the plugin for my setup and noticed that it extends the path for all fish sessions.

To keep the path clean of things we would usually never call directly I've moved the path extension into the function.

Sadly the `fish_add_path` function doesn't allow passing `--local`, therefore I needed to extend the path on my own :slightly_smiling_face: 